### PR TITLE
feat: AWS_PROFILE env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
   -as, --absolute-start <start>     Start time (ISO 8601)
   -ae, --absolute-end <end>         End time (ISO 8601)
   -f, --filter-expression <filter>  Filter expression. Must be inside double or single quotes ("/')
-  -p, --profile <profile>           AWS profile to use (default: "default")
+  -p, --profile <profile>           AWS profile to use (default: "default", env: AWS_PROFILE)
   -h, --help                        display help for command
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mhlabs/xray-cli",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mhlabs/xray-cli",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-xray": "^3.395.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mhlabs/xray-cli",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Command line interface for analysing AWS X-Ray traces",
   "main": "index.js",
   "author": "mhlabs",

--- a/src/commands/traces/index.js
+++ b/src/commands/traces/index.js
@@ -9,7 +9,7 @@ program
   .option("-as, --absolute-start <start>", "Start time (ISO 8601)")
   .option("-ae, --absolute-end <end>", "End time (ISO 8601)")
   .option("-f, --filter-expression <filter>", "Filter expression. Must be inside double or single quotes (\"/')")
-  .option("-p, --profile <profile>", "AWS profile to use", "default")
+  .addOption(new program.Option("-p, --profile <profile>", "AWS profile to use").default("default").env("AWS_PROFILE"))
   .action(async (cmd) => {
     await lib.run(cmd);
   });


### PR DESCRIPTION
## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

### Motivation

This CLI tool previously defaulted to using the `default` AWS profile and allowed the user to override that by passing a `--profile` option.

However, the AWS CLI and other tools will respect the `AWS_PROFILE` environment variable as well. This can be observed in documentation here:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles

To bring consistency with other tools and workflows and convenience for existing users of the environment variable, support for that env variable would be appreciated.

### Implementation

Commander natively supports using environment variables as inputs for options. An example can be seen here:
https://github.com/tj/commander.js/blob/master/examples/options-env.js

However, the fluent `.option` method doesn't support setting that configuration. An instance of the `Option` class has to be created to set that. The diff required here is fairly small:

```diff
-  .option("-p, --profile <profile>", "AWS profile to use", "default")
+  .addOption(new program.Option("-p, --profile <profile>", "AWS profile to use").default("default").env("AWS_PROFILE"))
```

### Impact

This change updates the command definition to support a value from that environment variable as well. The order of precedence is as follows:

1. Use the value explicitly provided via the `--profile` option.
2. If the option was not passed, use the value of `AWS_PROFILE` environment variable.
3. If `AWS_PROFILE` is not set, use `"default"`

If the user does not have the `AWS_PROFILE` environment variable set, then there is no user-facing impact or change at all.

After this change, this is what the help output looks like:

```
$ xray t -h
Usage: xray traces|t [options]

Find and render trace timeline. All parameters are optional.

Options:
  -s, --start <start>               Start time (minutes ago) (default: 5)
  -e, --end <end>                   End time (minutes ago) (default: 0)
  -as, --absolute-start <start>     Start time (ISO 8601)
  -ae, --absolute-end <end>         End time (ISO 8601)
  -f, --filter-expression <filter>  Filter expression. Must be inside double or single quotes ("/')
  -p, --profile <profile>           AWS profile to use (default: "default", env: AWS_PROFILE)
  -h, --help                        display help for command
```

## Checklist

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests 
* [x] Update docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

No test setup exists in the package, so tests were not added.